### PR TITLE
Fix table creation in DbalTransport

### DIFF
--- a/lib/Transport/Dbal/DbalTransport.php
+++ b/lib/Transport/Dbal/DbalTransport.php
@@ -64,7 +64,7 @@ class DbalTransport implements TransportInterface
             return;
         }
 
-        $this->_createTable($schema);
+        $this->createTable();
     }
 
     /**


### PR DESCRIPTION
Hi there!

I introduced the bundle into a project and noticed that the post generate schema in `DbalTransport` does not create the queue table specified in configuration.

This aims to fix this issue, I fixed also the tests.