### PR TITLE
Incompatible type for time_to_live delete query

### DIFF
--- a/lib/Transport/Dbal/DbalReceiver.php
+++ b/lib/Transport/Dbal/DbalReceiver.php
@@ -239,7 +239,7 @@ class DbalReceiver implements ReceiverInterface
             ->delete($this->tableName)
             ->andWhere('(time_to_live IS NOT NULL) AND (time_to_live < :now)')
             ->andWhere('delivery_id IS NULL')
-            ->setParameter(':now', new \DateTimeImmutable(), Type::DATETIMETZ_IMMUTABLE)
+            ->setParameter(':now', (new \DateTimeImmutable())->getTimestamp(), Type::INTEGER)
             ->execute()
         ;
 

--- a/tests/Transport/Dbal/DbalTransportTest.php
+++ b/tests/Transport/Dbal/DbalTransportTest.php
@@ -117,7 +117,7 @@ class DbalTransportTest extends TestCase
         $this->connection->executeUpdate(
             'DELETE FROM messenger WHERE ((time_to_live IS NOT NULL) AND (time_to_live < :now)) AND (delivery_id IS NULL)',
             Argument::any(),
-            [':now' => Type::DATETIMETZ_IMMUTABLE]
+            [':now' => Type::INTEGER]
         )->shouldBeCalled();
 
         // Re-deliver old messages


### PR DESCRIPTION
Converted _time_to_live_ value from **DateTimeImmutable** to **timestamp** in `DbalReceiver::removeExpiredMessages()`, according to column type. 

Previous solution was right for mysql but incompatible with postgres.