### PR TITLE
Headers don't exist

### DIFF
--- a/lib/Transport/Dbal/DbalSender.php
+++ b/lib/Transport/Dbal/DbalSender.php
@@ -81,7 +81,7 @@ class DbalSender implements SenderInterface
             'id' => $this->codec->encodeBinary(Uuid::uuid1()),
             'published_at' => new \DateTimeImmutable(),
             'body' => $encodedMessage['body'],
-            'headers' => $encodedMessage['headers'],
+            'headers' => $encodedMessage['headers'] ?? [],
             'properties' => [],
             'priority' => 0,
             'time_to_live' => null,

--- a/lib/Transport/Mongo/MongoSender.php
+++ b/lib/Transport/Mongo/MongoSender.php
@@ -64,7 +64,7 @@ class MongoSender implements SenderInterface
             '_id' => new ObjectId(),
             'published_at' => \time(),
             'body' => $encodedMessage['body'],
-            'headers' => $encodedMessage['headers'],
+            'headers' => $encodedMessage['headers'] ?? [],
             'properties' => [],
             'priority' => 0,
             'time_to_live' => null,


### PR DESCRIPTION
Looking at the original senders in the messenger component in SF 4.4 they use ?? [] to avoid notices with headers index not existing in the encoded message. 

I've added the same here so they avoid the php notice and work. 

Fixes #4 and should be backward compatible. 