### PR TITLE
Allow sync:// mode to still work

### DIFF
--- a/lib/DependencyInjection/Compiler/CheckDependencyPass.php
+++ b/lib/DependencyInjection/Compiler/CheckDependencyPass.php
@@ -22,7 +22,7 @@ class CheckDependencyPass implements CompilerPassInterface
             $urlParams = \parse_url($url);
 
             if (false === $urlParams) {
-                throw new InvalidConfigurationException(\sprintf('"%s" is not a valid URL', $url));
+                continue;
             }
 
             $scheme = $urlParams['scheme'] ?? null;

--- a/lib/DependencyInjection/Compiler/RegisterDoctrineEventsPass.php
+++ b/lib/DependencyInjection/Compiler/RegisterDoctrineEventsPass.php
@@ -19,7 +19,7 @@ class RegisterDoctrineEventsPass implements CompilerPassInterface
             $urlParams = \parse_url($url);
 
             if (false === $urlParams) {
-                throw new InvalidConfigurationException(\sprintf('"%s" is not a valid URL', $url));
+                continue;
             }
 
             if ('doctrine' === ($urlParams['scheme'] ?? '')) {


### PR DESCRIPTION
This will just ignore the sync:// setup, as it returns false for url_parse. 