### PR TITLE
resolve framework config before Processor::processConfiguration()

### DIFF
--- a/lib/Adapter/Serializer/ContextConverter.php
+++ b/lib/Adapter/Serializer/ContextConverter.php
@@ -14,10 +14,6 @@ final class ContextConverter
 {
     /**
      * Converts to SerializationContext.
-     *
-     * @param array $context
-     *
-     * @return SerializationContext
      */
     public static function toSerializationContext(array $context): SerializationContext
     {
@@ -32,10 +28,6 @@ final class ContextConverter
 
     /**
      * Converts to DeserializationContext.
-     *
-     * @param array $context
-     *
-     * @return DeserializationContext
      */
     public static function toDeserializationContext(array $context): DeserializationContext
     {

--- a/lib/DependencyInjection/Compiler/CheckDependencyPass.php
+++ b/lib/DependencyInjection/Compiler/CheckDependencyPass.php
@@ -5,7 +5,6 @@ namespace Kcs\MessengerExtra\DependencyInjection\Compiler;
 use Kcs\MessengerExtra\Transport\Dbal\DbalTransportFactory;
 use Ramsey\Uuid\Doctrine\UuidBinaryType;
 use Ramsey\Uuid\UuidInterface;
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 

--- a/lib/DependencyInjection/Compiler/RegisterDoctrineEventsPass.php
+++ b/lib/DependencyInjection/Compiler/RegisterDoctrineEventsPass.php
@@ -2,7 +2,6 @@
 
 namespace Kcs\MessengerExtra\DependencyInjection\Compiler;
 
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 

--- a/lib/DependencyInjection/Compiler/SerializerContextConfigurationPass.php
+++ b/lib/DependencyInjection/Compiler/SerializerContextConfigurationPass.php
@@ -18,7 +18,10 @@ class SerializerContextConfigurationPass implements CompilerPassInterface
         if ($container->hasExtension('framework')) {
             /** @var FrameworkExtension $framework */
             $framework = $container->getExtension('framework');
+            $resolvingBag = $container->getParameterBag();
+
             $frameworkConfigs = $container->getExtensionConfig('framework');
+            $frameworkConfigs = $resolvingBag->resolveValue($frameworkConfigs);
 
             $processor = new Processor();
             $config = $processor->processConfiguration($framework->getConfiguration([], $container), $frameworkConfigs);

--- a/lib/DependencyInjection/Compiler/SerializerContextConfigurationPass.php
+++ b/lib/DependencyInjection/Compiler/SerializerContextConfigurationPass.php
@@ -18,7 +18,9 @@ class SerializerContextConfigurationPass implements CompilerPassInterface
         if ($container->hasExtension('framework')) {
             /** @var FrameworkExtension $framework */
             $framework = $container->getExtension('framework');
+
             $frameworkConfigs = $container->getExtensionConfig('framework');
+            $frameworkConfigs = $container->resolveEnvPlaceholders($frameworkConfigs, true);
 
             $processor = new Processor();
             $config = $processor->processConfiguration($framework->getConfiguration([], $container), $frameworkConfigs);

--- a/lib/Message/DelayedMessageInterface.php
+++ b/lib/Message/DelayedMessageInterface.php
@@ -12,8 +12,6 @@ interface DelayedMessageInterface
     /**
      * Gets the delay (in milliseconds) that must elapse for this message to be
      * delivered after it was sent.
-     *
-     * @return int
      */
     public function getDelay(): int;
 }

--- a/lib/Message/PriorityAwareMessageInterface.php
+++ b/lib/Message/PriorityAwareMessageInterface.php
@@ -10,8 +10,6 @@ interface PriorityAwareMessageInterface
      *
      * All the messages that are not implementing this interface are
      * published with priority = 0
-     *
-     * @return int
      */
     public function getPriority(): int;
 }

--- a/lib/Message/TTLAwareMessageInterface.php
+++ b/lib/Message/TTLAwareMessageInterface.php
@@ -11,8 +11,6 @@ interface TTLAwareMessageInterface
 {
     /**
      * Gets the time-to-live (in seconds) for this message.
-     *
-     * @return int
      */
     public function getTtl(): int;
 }

--- a/lib/Message/UniqueMessageInterface.php
+++ b/lib/Message/UniqueMessageInterface.php
@@ -12,8 +12,6 @@ interface UniqueMessageInterface
     /**
      * The uniqueness key of this message.
      * Will be used to determine if another message is present in the queue.
-     *
-     * @return string
      */
     public function getUniquenessKey(): string;
 }

--- a/lib/Transport/Dbal/DbalReceiver.php
+++ b/lib/Transport/Dbal/DbalReceiver.php
@@ -291,8 +291,6 @@ class DbalReceiver implements ReceiverInterface, MessageCountAwareInterface, Lis
 
     /**
      * Redeliver a single message.
-     *
-     * @param string $id
      */
     private function redeliver(string $id): void
     {

--- a/lib/Transport/Dbal/DbalSender.php
+++ b/lib/Transport/Dbal/DbalSender.php
@@ -104,7 +104,7 @@ class DbalSender implements SenderInterface
         if ($message instanceof UniqueMessageInterface) {
             $uniqKey = $message->getUniquenessKey();
             if (\mb_strlen($uniqKey) >= 60) {
-                $uniqKey = sha1($uniqKey);
+                $uniqKey = \sha1($uniqKey);
             }
 
             $expr = $this->connection->getExpressionBuilder();

--- a/lib/Transport/Dbal/DbalTransport.php
+++ b/lib/Transport/Dbal/DbalTransport.php
@@ -54,8 +54,6 @@ class DbalTransport implements TransportInterface, ListableReceiverInterface, Me
 
     /**
      * Register the table into the doctrine schema.
-     *
-     * @param GenerateSchemaEventArgs $eventArgs
      */
     public function postGenerateSchema(GenerateSchemaEventArgs $eventArgs): void
     {

--- a/lib/Transport/Mongo/MongoReceiver.php
+++ b/lib/Transport/Mongo/MongoReceiver.php
@@ -93,7 +93,7 @@ class MongoReceiver implements ReceiverInterface, ListableReceiverInterface, Mes
             $options['limit'] = $limit;
         }
 
-        foreach ($this->collection->find([], $options) as $deliveredMessage){
+        foreach ($this->collection->find([], $options) as $deliveredMessage) {
             yield $this->hydrate((array) $deliveredMessage);
         }
     }

--- a/lib/Transport/Mongo/MongoSender.php
+++ b/lib/Transport/Mongo/MongoSender.php
@@ -10,7 +10,6 @@ use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
-use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
@@ -61,7 +60,7 @@ class MongoSender implements SenderInterface
 
         $values = [
             '_id' => new ObjectId(),
-            'published_at' => (int)(\microtime(true)*10000),
+            'published_at' => (int) (\microtime(true) * 10000),
             'body' => $encodedMessage['body'],
             'headers' => $encodedMessage['headers'] ?? [],
             'properties' => [],

--- a/lib/Utils/UrlUtils.php
+++ b/lib/Utils/UrlUtils.php
@@ -6,10 +6,6 @@ class UrlUtils
 {
     /**
      * Build URL from parse_url array params.
-     *
-     * @param array $url
-     *
-     * @return string
      */
     public static function buildUrl(array $url): string
     {

--- a/tests/Transport/Dbal/DbalTransportTest.php
+++ b/tests/Transport/Dbal/DbalTransportTest.php
@@ -136,7 +136,7 @@ class DbalTransportTest extends TestCase
         $this->connection
             ->executeQuery('SELECT id FROM messenger WHERE (uniq_key = :uniq_key) AND (delivery_id IS NULL)', ['uniq_key' => 'uniq'], [])
             ->willReturn(new ArrayStatement([
-                [ 'id' => Uuid::uuid4()->getBytes() ],
+                ['id' => Uuid::uuid4()->getBytes()],
             ]));
 
         $this->connection->insert(Argument::cetera())->shouldNotBeCalled();

--- a/tests/Transport/Dbal/IntegrationTest.php
+++ b/tests/Transport/Dbal/IntegrationTest.php
@@ -93,7 +93,7 @@ class IntegrationTest extends TestCase
         $thirdArgument = $workerClass->getConstructor()->getParameters()[2];
 
         $type = $thirdArgument->getType();
-        if ($type instanceof \ReflectionNamedType && $type->getName() === EventDispatcherInterface::class) {
+        if ($type instanceof \ReflectionNamedType && EventDispatcherInterface::class === $type->getName()) {
             $worker = new Worker([$this->transport], new MessageBus(), $eventDispatcher = new EventDispatcher());
         } else {
             $worker = new Worker([$this->transport], new MessageBus(), [], $eventDispatcher = new EventDispatcher());

--- a/tests/Transport/Mongo/IntegrationTest.php
+++ b/tests/Transport/Mongo/IntegrationTest.php
@@ -67,7 +67,7 @@ class IntegrationTest extends TestCase
         $receivedMessages = 0;
         $workerClass = new \ReflectionClass(Worker::class);
         $thirdArgument = $workerClass->getConstructor()->getParameters()[2];
-        if ((string) $thirdArgument->getType() === EventDispatcherInterface::class) {
+        if (EventDispatcherInterface::class === (string) $thirdArgument->getType()) {
             $worker = new Worker([$this->transport], new MessageBus(), $eventDispatcher = new EventDispatcher());
         } else {
             $worker = new Worker([$this->transport], new MessageBus(), [], $eventDispatcher = new EventDispatcher());

--- a/tests/Transport/Mongo/MongoReceiverTest.php
+++ b/tests/Transport/Mongo/MongoReceiverTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Kcs\MessengerExtra\Tests\Transport\Mongo;
 
@@ -23,9 +23,9 @@ class MongoReceiverTest extends TestCase
         $mongoCollection->method('find')->with([], ['limit' => 20])->willReturn([$envelope1, $envelope2]);
 
         $receiver = new MongoReceiver($mongoCollection, $serializer);
-        $actualEnvelopes = iterator_to_array($receiver->all(20));
-        $this->assertCount(2, $actualEnvelopes);
-        $this->assertEquals(new DummyMessage('Hi'), $actualEnvelopes[0]->getMessage());
+        $actualEnvelopes = \iterator_to_array($receiver->all(20));
+        self::assertCount(2, $actualEnvelopes);
+        self::assertEquals(new DummyMessage('Hi'), $actualEnvelopes[0]->getMessage());
     }
 
     public function testFind()
@@ -38,7 +38,7 @@ class MongoReceiverTest extends TestCase
 
         $receiver = new MongoReceiver($mongoCollection, $serializer);
         $actualEnvelope = $receiver->find('5a2493c33c95a1281836eb6a');
-        $this->assertEquals(new DummyMessage('Hi'), $actualEnvelope->getMessage());
+        self::assertEquals(new DummyMessage('Hi'), $actualEnvelope->getMessage());
     }
 
     private function createEnvelope()

--- a/tests/Transport/Mongo/MongoTransportTest.php
+++ b/tests/Transport/Mongo/MongoTransportTest.php
@@ -2,7 +2,6 @@
 
 namespace Kcs\MessengerExtra\Tests\Transport\Mongo;
 
-use Doctrine\DBAL\Types\Type;
 use Kcs\MessengerExtra\Message\DelayedMessageInterface;
 use Kcs\MessengerExtra\Message\PriorityAwareMessageInterface;
 use Kcs\MessengerExtra\Message\TTLAwareMessageInterface;
@@ -108,11 +107,12 @@ class MongoTransportTest extends TestCase
 
         self::assertNotEmpty($envelope->last(TransportMessageIdStamp::class)->getId());
     }
-    
+
     public function testSendWithSymfonyDelayStamp(): void
     {
         $delay = 5000;
-        $message = new class() {};
+        $message = new class() {
+        };
 
         $this->collection->insertOne(Argument::allOf(
             Argument::withEntry('delayed_until', Argument::type('int'))


### PR DESCRIPTION
The configuration may contain links to data from the environment. What can cause errors in
Symfony\Component\Config\Definition\Processor::processConfiguration()