### PR TITLE
remove redeliver calls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,11 @@ jobs:
                 env:
                     MONGO_INITDB_ROOT_USERNAME: ${{ matrix.versions[4] }}
                     MONGO_INITDB_ROOT_PASSWORD: ${{ matrix.versions[5] }}
+                options: >-
+                    --health-cmd mongo
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
                 ports:
                     - 27017:27017
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,8 +8,8 @@
          enforceTimeLimit="true"
          failOnRisky="true"
          timeoutForSmallTests="5"
-         timeoutForMediumTests="5"
-         timeoutForLargeTests="10"
+         timeoutForMediumTests="10"
+         timeoutForLargeTests="30"
 >
   <coverage>
     <include>

--- a/tests/Fixtures/DummyMessageHandler.php
+++ b/tests/Fixtures/DummyMessageHandler.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Kcs\MessengerExtra\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+class DummyMessageHandler implements MessageHandlerInterface
+{
+    public static int $count = 0;
+
+    public function __invoke(DummyMessage $message)
+    {
+        if (self::$count++ === 1) {
+            return;
+        }
+
+        throw new \Exception();
+    }
+}

--- a/tests/Transport/Mongo/IntegrationTest.php
+++ b/tests/Transport/Mongo/IntegrationTest.php
@@ -2,7 +2,9 @@
 
 namespace Kcs\MessengerExtra\Tests\Transport\Mongo;
 
+use Composer\InstalledVersions;
 use Kcs\MessengerExtra\Tests\Fixtures\DummyMessage;
+use Kcs\MessengerExtra\Tests\Fixtures\DummyMessageHandler;
 use Kcs\MessengerExtra\Tests\Fixtures\UniqueDummyMessage;
 use Kcs\MessengerExtra\Transport\Mongo\MongoTransport;
 use Kcs\MessengerExtra\Transport\Mongo\MongoTransportFactory;
@@ -10,10 +12,23 @@ use Kcs\MessengerExtra\Utils\UrlUtils;
 use MongoDB\Client;
 use MongoDB\Driver\Exception\ConnectionTimeoutException;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
+use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
+use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
+use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+use Symfony\Component\Messenger\Transport\Serialization\Normalizer\FlattenExceptionNormalizer;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Worker;
 use Symfony\Component\Serializer as SerializerComponent;
@@ -26,20 +41,34 @@ class IntegrationTest extends TestCase
 {
     private MongoTransport $transport;
     private string $mongoUri;
+    private MongoTransport $failureTransport;
 
     protected function setUp(): void
     {
-        $serializer = new Serializer(
-            new SerializerComponent\Serializer([
-                new SerializerComponent\Normalizer\ObjectNormalizer(),
-            ], [
-                'json' => new SerializerComponent\Encoder\JsonEncoder(),
-            ])
-        );
+        if (version_compare(InstalledVersions::getVersion('symfony/messenger'), '5.2.0', '>=')) {
+            $serializer = new Serializer(
+                new SerializerComponent\Serializer([
+                    new SerializerComponent\Normalizer\DateTimeZoneNormalizer(),
+                    new SerializerComponent\Normalizer\DateTimeNormalizer(),
+                    new FlattenExceptionNormalizer(),
+                    new SerializerComponent\Normalizer\ArrayDenormalizer(),
+                    new SerializerComponent\Normalizer\ObjectNormalizer(),
+                ], [
+                    'json' => new SerializerComponent\Encoder\JsonEncoder(),
+                ])
+            );
+        } else {
+            $serializer = new PhpSerializer();
+        }
 
         $this->mongoUri = \getenv('MONGODB_URI') ?: 'mongodb://localhost:27017/';
+
+        $params = \parse_url($this->mongoUri);
+        $params['path'] = '/';
+
         $factory = new MongoTransportFactory();
-        $this->transport = $factory->createTransport($this->mongoUri, [], $serializer);
+        $this->transport = $factory->createTransport(UrlUtils::buildUrl(['path' => '/default/queue'] + $params), [], $serializer);
+        $this->failureTransport = $factory->createTransport(UrlUtils::buildUrl(['path' => '/default/failed'] + $params), [], $serializer);
 
         try {
             $this->dropCollection();
@@ -51,6 +80,86 @@ class IntegrationTest extends TestCase
     protected function tearDown(): void
     {
         $this->dropCollection();
+    }
+
+    /**
+     * @medium
+     */
+    public function testCorrectlyHandlesRejections(): void
+    {
+        DummyMessageHandler::$count = 0;
+        $container = new ServiceLocator([
+            'dummy_transport' => fn () => $this->transport,
+        ]);
+
+        $messageBus = new MessageBus([
+            new AddBusNameStampMiddleware('dummy'),
+            new DispatchAfterCurrentBusMiddleware(),
+            new FailedMessageProcessingMiddleware(),
+            new SendMessageMiddleware(new SendersLocator([
+                DummyMessage::class => ['dummy_transport'],
+            ], $container)),
+            new HandleMessageMiddleware(new HandlersLocator([
+                DummyMessage::class => [new DummyMessageHandler()],
+            ]))
+        ]);
+
+        $messageBus->dispatch(new DummyMessage('First'));
+        $messageBus->dispatch(new DummyMessage('Second'));
+
+        self::assertCount(2, $this->transport->all());
+        self::assertEquals(2, $this->transport->getMessageCount());
+
+        $receivedMessages = 0;
+        $workerClass = new \ReflectionClass(Worker::class);
+        $thirdArgument = $workerClass->getConstructor()->getParameters()[2];
+
+        $type = $thirdArgument->getType();
+        if ($type instanceof \ReflectionNamedType && EventDispatcherInterface::class === $type->getName()) {
+            $worker = new Worker(['dummy_transport' => $this->transport], $messageBus, $eventDispatcher = new EventDispatcher());
+        } else {
+            $worker = new Worker(['dummy_transport' => $this->transport], $messageBus, [], $eventDispatcher = new EventDispatcher());
+        }
+
+        $retryStrategy = new class implements RetryStrategyInterface {
+            private int $retry = 0;
+
+            public function isRetryable(Envelope $message): bool
+            {
+                return $this->retry++ < 2;
+            }
+
+            public function getWaitingTime(Envelope $message): int
+            {
+                return 1;
+            }
+        };
+
+        if (version_compare(InstalledVersions::getVersion('symfony/messenger'), '5.3.0', '<')) {
+            $eventDispatcher->addSubscriber(new SendFailedMessageToFailureTransportListener($this->failureTransport));
+        } else {
+            $eventDispatcher->addSubscriber(new SendFailedMessageToFailureTransportListener(new ServiceLocator([
+                'dummy_transport' => fn() => $this->failureTransport,
+            ])));
+        }
+
+        $retryStrategyLocator = new ServiceLocator([
+            'dummy_transport' => fn () => $retryStrategy,
+        ]);
+
+        $eventDispatcher->addSubscriber(new SendFailedMessageForRetryListener($container, $retryStrategyLocator));
+        $eventDispatcher->addListener(WorkerMessageReceivedEvent::class,
+            static function () use (&$receivedMessages, $worker) {
+                if (4 === ++$receivedMessages) {
+                    $worker->stop();
+                }
+            });
+
+        $worker->run();
+
+        self::assertCount(0, $this->transport->all());
+        self::assertCount(1, $this->failureTransport->all());
+        self::assertEquals(4, $receivedMessages);
     }
 
     /**
@@ -119,5 +228,6 @@ class IntegrationTest extends TestCase
 
         $client = new Client(UrlUtils::buildUrl($params), $auth);
         $client->default->queue->drop();
+        $client->default->failed->drop();
     }
 }


### PR DESCRIPTION
In dbal and mongodb receivers if an error is thrown, a `redeliver` call was fired as a part of error handling routine.
This modification allows the retry strategy (and listeners) to handle that error too.